### PR TITLE
Changed Interpolation step size to 0.00962188

### DIFF
--- a/Epoch_06_12_14_Normalization.py
+++ b/Epoch_06_12_14_Normalization.py
@@ -154,8 +154,9 @@ remove_small(Normal_TFS1,0.02)
 remove_small(Normal_TFS2,0.02)
 remove_small(Normal_TFS3,0.02)
 
-TWL1_TWL2= arange(TWL1[0],TWL2[-1],.00997)
-TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],0.0122408)
+Largest_WL_spacing=0.00962188# The largest Wavelength spacing in the data you are working with. ie the spacing between Wavelength[i+1]-Wavelength[i]
+TWL1_TWL2= arange(TWL1[0],TWL2[-1],Largest_WL_spacing)
+TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],Largest_WL_spacing)
 
 Iflux1=interp(TWL1_TWL2,TWL1,Normal_TFS1,left=0,right=0)
 Ierror1=interp(TWL1_TWL2,TWL1,ER1,left=0,right=0)

--- a/Epoch_06_14_15_Normalization.py
+++ b/Epoch_06_14_15_Normalization.py
@@ -155,8 +155,9 @@ remove_small(Normal_TFS1,0.02)
 remove_small(Normal_TFS2,0.02)
 remove_small(Normal_TFS3,0.02)
 
-TWL1_TWL2= arange(TWL1[0],TWL2[-1],.00997)
-TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],0.0122408)
+Largest_WL_spacing=0.00962188# The largest Wavelength spacing in the data you are working with. ie the spacing between Wavelength[i+1]-Wavelength[i]
+TWL1_TWL2= arange(TWL1[0],TWL2[-1],Largest_WL_spacing)
+TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],Largest_WL_spacing)
 
 Iflux1=interp(TWL1_TWL2,TWL1,Normal_TFS1,left=0,right=0)
 Ierror1=interp(TWL1_TWL2,TWL1,ER1,left=0,right=0)

--- a/Epoch_06_1_14_Normalization.py
+++ b/Epoch_06_1_14_Normalization.py
@@ -154,8 +154,9 @@ remove_small(Normal_TFS1,0.02)
 remove_small(Normal_TFS2,0.02)
 remove_small(Normal_TFS3,0.02)
 
-TWL1_TWL2= arange(TWL1[0],TWL2[-1],.00997)
-TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],0.0122408)
+Largest_WL_spacing=0.00962188# The largest Wavelength spacing in the data you are working with. ie the spacing between Wavelength[i+1]-Wavelength[i]
+TWL1_TWL2= arange(TWL1[0],TWL2[-1],Largest_WL_spacing)
+TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],Largest_WL_spacing)
 
 Iflux1=interp(TWL1_TWL2,TWL1,Normal_TFS1,left=0,right=0)
 Ierror1=interp(TWL1_TWL2,TWL1,ER1,left=0,right=0)

--- a/Epoch_06_28_14_Normalization.py
+++ b/Epoch_06_28_14_Normalization.py
@@ -154,8 +154,9 @@ remove_small(Normal_TFS1,0.02)
 remove_small(Normal_TFS2,0.02)
 remove_small(Normal_TFS3,0.02)
 
-TWL1_TWL2= arange(TWL1[0],TWL2[-1],.00997)
-TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],0.0122408)
+Largest_WL_spacing=0.00962188# The largest Wavelength spacing in the data you are working with. ie the spacing between Wavelength[i+1]-Wavelength[i]
+TWL1_TWL2= arange(TWL1[0],TWL2[-1],Largest_WL_spacing)
+TWL1_TWL2_TWL3= arange(TWL1[0],TWL3[-1],Largest_WL_spacing)
 
 Iflux1=interp(TWL1_TWL2,TWL1,Normal_TFS1,left=0,right=0)
 Ierror1=interp(TWL1_TWL2,TWL1,ER1,left=0,right=0)


### PR DESCRIPTION
The following lines of code were used to find the spacing between the wavelength axis(could not find the value in the header file, please tell me the keyword)

print(Epoch_06_1_14_Normalization.wavelength1[1][101]-Epoch_06_1_14_Normalization.wavelength1[1][100])
print(Epoch_06_12_14_Normalization.wavelength1[1][101]-Epoch_06_12_14_Normalization.wavelength1[1][100])
print(Epoch_06_28_14_Normalization.wavelength1[1][101]-Epoch_06_28_14_Normalization.wavelength1[1][100])
print(Epoch_06_14_15_Normalization.wavelength1[1][101]-Epoch_06_14_15_Normalization.wavelength1[1][100])

Running this yields:
0.00996218867976<- largest
0.00996216042813
0.00996218052978
0.00996215948044

The largest of these values was taken to interpolate as to not create fake data.